### PR TITLE
Surface some errors in communication

### DIFF
--- a/Watch Extension/AppState.swift
+++ b/Watch Extension/AppState.swift
@@ -19,12 +19,14 @@ struct AppState {
     var activeFeedings: [Feeding] = []
     var timerPulseCount: Int = 0
     var session: SessionState = .loggedOut
+    var didCommunicationFail = false
 }
 
 enum AppAction {
     case loggedIn
     case loggedOut
     case timerPulse
+    case clearFailedCommunication
     case start(type: FeedingType, side: FeedingSide)
     case stop(Feeding)
     case pause(Feeding)
@@ -40,21 +42,26 @@ func appReducer(value: inout AppState, action: AppAction) {
         value.session = .loggedOut
     case .timerPulse:
         value.timerPulseCount += 1
+    case .clearFailedCommunication:
+        value.didCommunicationFail = false
     case let .start(type, side):
         let info = WatchCommunication(type: type,
                                       side: side,
                                       action: .start)
+
         let jsonEncoder = JSONEncoder()
-        guard let d = try? jsonEncoder.encode(info) else {
-            // TODO: what do we do here?
+        guard let d = try? jsonEncoder.encode(info), WCSession.default.isReachable else {
+            value.didCommunicationFail = true
             return
         }
 
-        WCSession.default.sendMessageData(d, replyHandler: nil) { e in
-            print("Error sending the message: \(e.localizedDescription)")
+        WCSession.default.sendMessageData(d, replyHandler: nil) { error in
+            // TODO: should gracefully handle a failure here
+            print("Error sending the message: \(error.localizedDescription)")
         }
-        // TODO: this should be placed in the success blok from the communication
-        // TODO: need to gracefully handle a failure here
+        // TODO: this should really be placed in the success block
+        // from the communication above, but mutating the value in an
+        // escaping block needs to be worked out. Can we send from the block?
         let feeding = Feeding(start: Date(), type: type, side: side)
         value.activeFeedings.append(feeding)
     case let .stop(feeding):
@@ -62,25 +69,32 @@ func appReducer(value: inout AppState, action: AppAction) {
                                       side: feeding.side,
                                       action: .stop)
         let jsonEncoder = JSONEncoder()
-        guard let d = try? jsonEncoder.encode(info) else {
-            // TODO: what do we do here?
+        guard let d = try? jsonEncoder.encode(info), WCSession.default.isReachable else {
+            value.didCommunicationFail = true
             return
         }
-        WCSession.default.sendMessageData(d, replyHandler: nil) { e in
-            print("Error sending the message: \(e.localizedDescription)")
+
+        WCSession.default.sendMessageData(d, replyHandler: nil) { error in
+            // TODO: should gracefully handle a failure here
+            print("Error sending the message: \(error.localizedDescription)")
         }
+        // TODO: this should really be placed in the success block
+        // from the communication above, but mutating the value in an
+        // escaping block needs to be worked out. Can we send from the block?
         value.activeFeedings.removeAll { $0.id == feeding.id }
     case let .pause(feeding):
         let info = WatchCommunication(type: feeding.type,
                                       side: feeding.side,
                                       action: .pause)
         let jsonEncoder = JSONEncoder()
-        guard let d = try? jsonEncoder.encode(info) else {
-            // TODO: what do we do here?
+        guard let d = try? jsonEncoder.encode(info), WCSession.default.isReachable else {
+            value.didCommunicationFail = true
             return
         }
-        WCSession.default.sendMessageData(d, replyHandler: nil) { e in
-            print("Error sending the message: \(e.localizedDescription)")
+
+        WCSession.default.sendMessageData(d, replyHandler: nil) { error in
+            // TODO: should gracefully handle a failure here
+            print("Error sending the message: \(error.localizedDescription)")
         }
     }
 }

--- a/Watch Extension/AppState.swift
+++ b/Watch Extension/AppState.swift
@@ -33,6 +33,7 @@ enum AppAction {
 }
 
 // TODO: see what can be DRY-ed up here
+// swiftlint:disable function_body_length
 func appReducer(value: inout AppState, action: AppAction) {
     switch action {
     // TODO: can logged out and logged in be combined?
@@ -98,3 +99,4 @@ func appReducer(value: inout AppState, action: AppAction) {
         }
     }
 }
+// swiftlint:enable function_body_length

--- a/Watch Extension/HomeView.swift
+++ b/Watch Extension/HomeView.swift
@@ -8,7 +8,6 @@ import SwiftUI
    behaves well from a UI standpoint when using the watch
  - Think about subscriptions or IAP for this
  - Load all feedings when starting up?
- - Make sure iPhone is available when sending messages
  - What to do with bottle feeding?
  */
 

--- a/Watch Extension/LoggedInHomeView.swift
+++ b/Watch Extension/LoggedInHomeView.swift
@@ -3,31 +3,63 @@ import SwiftUI
 struct LoggedInHomeView: View {
     @ObservedObject var store: Store<AppState, AppAction>
     @State private var isShowingSheet = false
-    var body: some View {
-        // TODO: think more about the layout of these two
-        VStack {
-            List(store.value.activeFeedings.reversed()) { feeding in
-                HStack {
-                    Spacer()
-                    FeedingView(store: self.store, feeding: feeding)
-                        .layoutPriority(1.0)
-                    Spacer()
-                }
-            }
 
-            // TODO: better style this
-            Image(systemName: "xmark.circle.fill")
-                .font(.system(size: 55))
-                .rotationEffect(.init(degrees: 45))
-                .offset(y: -10)
-                .sheet(isPresented: $isShowingSheet) {
-                    AddFeedingView(store: self.store, isShowingSheet: self.$isShowingSheet)
+    private func alertDimension(for metrics: GeometryProxy) -> CGFloat {
+        store.value.didCommunicationFail ? metrics.size.width * 0.9 : 10
+    }
+
+    var body: some View {
+        ZStack {
+            // TODO: think more about the layout of these two
+            VStack {
+                List(store.value.activeFeedings.reversed()) { feeding in
+                    HStack {
+                        Spacer()
+                        FeedingView(store: self.store, feeding: feeding)
+                            .layoutPriority(1.0)
+                        Spacer()
+                    }
+                }
+
+                // TODO: better style this
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 55))
+                    .rotationEffect(.init(degrees: 45))
+                    .offset(y: -10)
+                    .sheet(isPresented: $isShowingSheet) {
+                        AddFeedingView(store: self.store, isShowingSheet: self.$isShowingSheet)
                 }
                 .gesture(TapGesture().onEnded {
                     self.isShowingSheet.toggle()
                 })
+            }
+            .edgesIgnoringSafeArea(.bottom)
+
+            GeometryReader { metrics in
+                ZStack {
+                    Rectangle()
+                        .cornerRadius(12)
+                        .foregroundColor(Color.blue)
+                        .opacity(0.96)
+
+                    VStack {
+                        Text("Connection Issue")
+                            .bold()
+                        Text("\nTry again or open main app.")
+                            .layoutPriority(1.0)
+                    }
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(Color.white)
+                    .animation(.none)
+                }
+                .frame(width: self.alertDimension(for: metrics), height: self.alertDimension(for: metrics))
+            }
+            .opacity(self.store.value.didCommunicationFail ? 1.0 : 0.0)
+            .animation(.spring(response: 0.45, dampingFraction: 0.7))
+            .gesture(TapGesture().onEnded {
+                self.store.send(.clearFailedCommunication)
+            })
         }
-        .edgesIgnoringSafeArea(.bottom)
     }
 }
 
@@ -35,6 +67,6 @@ struct LoggedInHomeView: View {
 struct LoggedInHomeView_Previews: PreviewProvider {
 // swiftlint:enable type_name
     static var previews: some View {
-        HomeView(store: Store(initialValue: AppState(), reducer: appReducer))
+        LoggedInHomeView(store: Store(initialValue: AppState(), reducer: appReducer))
     }
 }


### PR DESCRIPTION
Alert error will be shown when reachability is false or if we can't encode the info to send.

Handling the error completion handler when sending a message is something for the future since that is a bit trickier.