### PR TITLE
Cut bottle feeding from v1 scope

### DIFF
--- a/Watch Extension/AddFeedingView.swift
+++ b/Watch Extension/AddFeedingView.swift
@@ -20,26 +20,20 @@ struct FeedingOptionsView: View {
                 Image(systemName: "n.circle.fill")
                     .font(.system(size: 55))
                     .scaleEffect(isAdding(feeding: feedingIntent) ? 0.5 : 1)
+                    .blur(radius: isAdding(feeding: feedingIntent) ? 1.0 : 0)
+                    .opacity(isAdding(feeding: feedingIntent) ? 0.5 : 1.0)
                     .gesture(TapGesture().onEnded {
                         withAnimation(.spring(response: 0.35, dampingFraction: 0.65)) { self.feedingIntent = .nursing }
                     })
                 Spacer()
+                Spacer()
                 Image(systemName: "p.circle.fill")
                     .font(.system(size: 55))
                     .scaleEffect(isAdding(feeding: feedingIntent) ? 0.5 : 1)
+                    .opacity(isAdding(feeding: feedingIntent) ? 0.5 : 1.0)
+                    .blur(radius: isAdding(feeding: feedingIntent) ? 1.0 : 0)
                     .gesture(TapGesture().onEnded {
                         withAnimation(.spring(response: 0.35, dampingFraction: 0.65)) { self.feedingIntent = .pumping }
-                    })
-                Spacer()
-            }
-            Spacer()
-            HStack {
-                Spacer()
-                Image(systemName: "b.circle.fill")
-                    .font(.system(size: 55))
-                    .scaleEffect(isAdding(feeding: feedingIntent) ? 0.5 : 1)
-                    .gesture(TapGesture().onEnded {
-                        withAnimation(.spring(response: 0.35, dampingFraction: 0.65)) { self.feedingIntent = .bottle }
                     })
                 Spacer()
             }

--- a/Watch Extension/HomeView.swift
+++ b/Watch Extension/HomeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
    behaves well from a UI standpoint when using the watch
  - Think about subscriptions or IAP for this
  - Load all feedings when starting up?
- - What to do with bottle feeding?
+ - Don't allow addition of feeding if it is already in progress
  */
 
 struct HomeView: View {


### PR DESCRIPTION
- Simplifies v1 a bit and isn't as important as the other types of feeding
- Polish up adding new feeding UI a bit for clarity