### PR TITLE
Prevent starting duplicate feedings

### DIFF
--- a/Watch Extension/HomeView.swift
+++ b/Watch Extension/HomeView.swift
@@ -9,7 +9,6 @@ import SwiftUI
    behaves well from a UI standpoint when using the watch
  - Think about subscriptions or IAP for this
  - Load all feedings when starting up?
- - Don't allow addition of feeding if it is already in progress
  */
 
 struct HomeView: View {


### PR DESCRIPTION
The main app is currently not set up to allow
starting duplicate feedings of the same type.
This prevents that case.