### PR TITLE
Account for paused feeding

### DIFF
--- a/BabyPatterns/DispatchVC.swift
+++ b/BabyPatterns/DispatchVC.swift
@@ -219,8 +219,11 @@ extension DispatchVC: WCSessionDelegate {
                 NotificationCenter.default.post(name: K.Notifications.showSavedFyiDialog, object: nil)
             }
         case .pause:
-            guard let fip = vm.feedingInProgress(type: info.feedingType) else { return }
-            vm.updateFeedingInProgress(type: info.feedingType, side: info.feedingSide, isPaused: !fip.isPaused)
+            guard vm.feedingInProgress(type: info.feedingType) != nil else { return }
+            vm.updateFeedingInProgress(type: info.feedingType, side: info.feedingSide, isPaused: true)
+        case .resume:
+            guard vm.feedingInProgress(type: info.feedingType) != nil else { return }
+            vm.updateFeedingInProgress(type: info.feedingType, side: info.feedingSide, isPaused: false)
         }
 
         // FIXME: for some reason, the UI isn't updating as expected when killed

--- a/Common/Sources/Common/Enums.swift
+++ b/Common/Sources/Common/Enums.swift
@@ -8,7 +8,7 @@ public enum FeedingType: String, Codable {
 }
 
 public enum FeedingAction: Int, Codable {
-    case start, stop, pause
+    case start, stop, pause, resume
 }
 
 // TODO: decide on the below enums

--- a/Watch Extension/HomeView.swift
+++ b/Watch Extension/HomeView.swift
@@ -4,7 +4,6 @@ import SwiftUI
  TODO: - V1 Watch
  - Polish UI
  - Handle UI when main app manages an in-progress feeding
- - Get pause to actually pause
  - Make sure a backgrounded/terminated main app
    behaves well from a UI standpoint when using the watch
  - Think about subscriptions or IAP for this


### PR DESCRIPTION
The watch will now properly account for
paused time after a period of being paused.

Right now the UI just says "PAUSED".
In the future we can build out a blinking
paused timer label like the main app, but this
is okay for now.

Heavily based off of the main app's
implementation of the feeding struct. The
two different feeding structs (watch and iOS)
should be combined in the future.

I am not too crazy about duplicating the state
of in-progress feedings here, but due to the
difficulty in watch<>iOS app communication,
this is okay for now.

A resume action was formally built in too.