### PR TITLE
Stop main app communication to fix duplicate watch events

### DIFF
--- a/BabyPatterns/FeedingsVM+FeedingInProgress.swift
+++ b/BabyPatterns/FeedingsVM+FeedingInProgress.swift
@@ -21,9 +21,6 @@ extension FeedingsVM {
         fip.serverKey = serverKey
         feedings.append(fip)
 
-        if type != .bottle {
-            communicate(feeding: fip, action: .start)
-        }
     }
 
     // TODO: the term `feeding in progress` doesn't quite fit here, consider improving naming
@@ -56,10 +53,6 @@ extension FeedingsVM {
 
         updateInternalFeedingCache(fip: fip)
         updateFeedingOnServer(fip: fip)
-
-        if type != .bottle {
-            communicate(feeding: fip, action: .stop)
-        }
     }
 
     func updateFeedingInProgress(type: FeedingType, side _: FeedingSide, isPaused: Bool) {
@@ -74,11 +67,6 @@ extension FeedingsVM {
 
         updateInternalFeedingCache(fip: fip)
         updateFeedingOnServer(fip: fip)
-
-        if type != .bottle {
-            let action: FeedingAction = isPaused ? .pause : .resume
-            communicate(feeding: fip, action: action)
-        }
     }
 
     private func updateInternalFeedingCache(fip: Feeding) {
@@ -104,25 +92,5 @@ extension FeedingsVM {
             return nil
         }
         return feeding
-    }
-
-    // TODO: consider making this a global function or ?
-    // This is the third time copying and pasting this, but first time in this target
-    func communicate(feeding: Feeding, action: Common.FeedingAction) {
-        let info = WatchCommunication(type: feeding.type, side: feeding.side, action: action)
-
-        let jsonEncoder = JSONEncoder()
-        guard let d = try? jsonEncoder.encode(info), WCSession.default.isReachable else {
-            // TODO: show communication error?
-            return
-        }
-
-        WCSession.default.sendMessageData(
-            d,
-            replyHandler: { _ in /* noop */ },
-            errorHandler: { error in
-                // TODO: show communication error
-                print("Error sending the message: \(error.localizedDescription)")
-        })
     }
 }


### PR DESCRIPTION
Unfortunately, when sending a feeding
from the watch to the phone, the communication
would "boomerang" back to the watch and duplicate
what was just sent (e.g., duplicate feedings would show
up on the watch). This commit breaks that communication
for the time being.

This was an oversight on my part :(. That
is okay though, this exposed how fragile
things were getting and that we should probably
be using the context for the main app's communication.

By using the context, that will also give the watch the
potential of receiving all the logged feedings!