### PR TITLE
Improve synchronization of app state context (feedings and logged in state)

### DIFF
--- a/BabyPatterns.xcodeproj/project.pbxproj
+++ b/BabyPatterns.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		12227F1A235F23AE004049DB /* SavedFyiDialogReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12227F19235F23AE004049DB /* SavedFyiDialogReducer.swift */; };
 		12227F1C235F2460004049DB /* AppReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12227F1B235F2460004049DB /* AppReducer.swift */; };
 		12227F1E235F2481004049DB /* AppAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12227F1D235F2481004049DB /* AppAction.swift */; };
+		1233CA222369F62D009BAF8E /* ContextReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1233CA212369F62D009BAF8E /* ContextReducer.swift */; };
 		123616AE20C5F43500185A27 /* TurnOffAdsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123616AC20C5F43500185A27 /* TurnOffAdsVC.swift */; };
 		123616AF20C5F43500185A27 /* TurnOffAdsVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 123616AD20C5F43500185A27 /* TurnOffAdsVC.xib */; };
 		123D4F93233691EB00F164E5 /* Library.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 120F80211FBF0E9500D04E45 /* Library.framework */; };
@@ -231,6 +232,7 @@
 		12227F19235F23AE004049DB /* SavedFyiDialogReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedFyiDialogReducer.swift; sourceTree = "<group>"; };
 		12227F1B235F2460004049DB /* AppReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReducer.swift; sourceTree = "<group>"; };
 		12227F1D235F2481004049DB /* AppAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAction.swift; sourceTree = "<group>"; };
+		1233CA212369F62D009BAF8E /* ContextReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextReducer.swift; sourceTree = "<group>"; };
 		123616AC20C5F43500185A27 /* TurnOffAdsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnOffAdsVC.swift; sourceTree = "<group>"; };
 		123616AD20C5F43500185A27 /* TurnOffAdsVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TurnOffAdsVC.xib; sourceTree = "<group>"; };
 		123D4F8E233691EB00F164E5 /* LibraryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LibraryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -410,6 +412,7 @@
 				12227F1B235F2460004049DB /* AppReducer.swift */,
 				12227F13235E9A02004049DB /* NewFeedingReducer.swift */,
 				125BBC5F2367E37400CF3C70 /* FeedingReducer.swift */,
+				1233CA212369F62D009BAF8E /* ContextReducer.swift */,
 				12227F15235F2223004049DB /* AccountReducer.swift */,
 				12227F17235F232A004049DB /* PulseReducer.swift */,
 				12227F19235F23AE004049DB /* SavedFyiDialogReducer.swift */,
@@ -1239,6 +1242,7 @@
 				12F3EC29233D6BFB0051D52B /* HomeView.swift in Sources */,
 				12E38A412343CEB500940F07 /* UnidirectionalFlow.swift in Sources */,
 				12D0AF4B2347670A00725A56 /* TimerPulse.swift in Sources */,
+				1233CA222369F62D009BAF8E /* ContextReducer.swift in Sources */,
 				125BBC602367E37400CF3C70 /* FeedingReducer.swift in Sources */,
 				120478EF234BEBB600302AFD /* LoggedOutView.swift in Sources */,
 				12227F1C235F2460004049DB /* AppReducer.swift in Sources */,

--- a/Common/Sources/Common/WatchCommunication.swift
+++ b/Common/Sources/Common/WatchCommunication.swift
@@ -1,6 +1,6 @@
-import Swift
+import Foundation
 
-public struct WatchCommunication: Codable {
+public struct WatchFeedingCommunication: Codable {
     public let feedingType: FeedingType
     public let feedingSide: FeedingSide
     public let action: FeedingAction
@@ -9,5 +9,12 @@ public struct WatchCommunication: Codable {
         feedingType = type
         feedingSide = side
         self.action = action
+    }
+}
+
+public struct WatchContextCommunication: Codable {
+    let requestedOn: Date
+    public init(requestedOn: Date = Date()) {
+        self.requestedOn = requestedOn
     }
 }

--- a/Watch Extension/AddFeedingView.swift
+++ b/Watch Extension/AddFeedingView.swift
@@ -97,7 +97,7 @@ struct AddFeedingView: View {
     // TODO: consider making this a global function or in the session coordinator or ?
     // This is the first time of copy and paste
     func communicateFeedingStart(type: FeedingType, side: FeedingSide) {
-        let info = WatchCommunication(type: type, side: side, action: .start)
+        let info = WatchFeedingCommunication(type: type, side: side, action: .start)
 
         let jsonEncoder = JSONEncoder()
         guard let d = try? jsonEncoder.encode(info), WCSession.default.isReachable else {

--- a/Watch Extension/FeedingView.swift
+++ b/Watch Extension/FeedingView.swift
@@ -30,7 +30,7 @@ struct FeedingView: View {
     // TODO: consider making this a global function or in the session coordinator or ?
     // This is the second time of copy and paste
     func communicate(type: FeedingType, side: FeedingSide, action: Common.FeedingAction) {
-        let info = WatchCommunication(type: type, side: side, action: action)
+        let info = WatchFeedingCommunication(type: type, side: side, action: action)
 
         let jsonEncoder = JSONEncoder()
         guard let d = try? jsonEncoder.encode(info), WCSession.default.isReachable else {

--- a/Watch Extension/HomeView.swift
+++ b/Watch Extension/HomeView.swift
@@ -3,9 +3,7 @@ import SwiftUI
 /*
  TODO: - V1 Watch
  - Polish UI
- - Allow watch to refresh feedings from main app
-   + Refresh button? pull down? automatic?
- - Think about subscriptions or IAP for this
+ - clean up / fix popups
  */
 
 struct HomeView: View {

--- a/Watch Extension/State Management/AppAction.swift
+++ b/Watch Extension/State Management/AppAction.swift
@@ -7,6 +7,7 @@ enum AppAction {
     case savedFyiDialog(SavedFyiDialogAction)
     case newFeeding(NewFeedingAction)
     case feeding(FeedingAction)
+    case context(ContextAction)
 
     // TODO: consider auto-gen for this:
     // https://github.com/pointfreeco/swift-enum-properties
@@ -73,6 +74,17 @@ enum AppAction {
         set {
             guard case .feeding = self, let newValue = newValue else { return }
             self = .feeding(newValue)
+        }
+    }
+
+    var context: ContextAction? {
+        get {
+            guard case let .context(value) = self else { return nil }
+            return value
+        }
+        set {
+            guard case .context = self, let newValue = newValue else { return }
+            self = .context(newValue)
         }
     }
 }

--- a/Watch Extension/State Management/AppReducer.swift
+++ b/Watch Extension/State Management/AppReducer.swift
@@ -5,5 +5,6 @@ let appReducer: (inout AppState, AppAction) -> Void = combine(
     pullback(pulseReducer, value: \.timerPulseCount, action: \.pulse),
     pullback(savedFyiDialogReducer, value: \.showSavedFyiDialog, action: \.savedFyiDialog),
     pullback(newFeedingReducer, value: \.self, action: \.newFeeding),
-    pullback(feedingReducer, value: \.activeFeedings, action: \.feeding)
+    pullback(feedingReducer, value: \.activeFeedings, action: \.feeding),
+    pullback(contextReducer, value: \.self, action: \.context)
 )

--- a/Watch Extension/State Management/ContextReducer.swift
+++ b/Watch Extension/State Management/ContextReducer.swift
@@ -1,0 +1,20 @@
+import Common
+import Foundation
+import WatchConnectivity
+
+enum ContextAction {
+    case requestFullContext
+}
+
+// TODO: need to figure out how to remove the state from here since
+// there is no need to have it at all. This reducer is to just formalize
+// an action
+func contextReducer(state _: inout AppState, action: ContextAction) {
+    switch action {
+    case .requestFullContext:
+        let communication = WatchContextCommunication()
+        let encoder = JSONEncoder()
+        guard let data = try? encoder.encode(communication) else { return }
+        WCSession.default.sendMessageData(data, replyHandler: nil, errorHandler: nil)
+    }
+}


### PR DESCRIPTION
When starting the watch app, it will ask the main app for
the full app state in context form. The main app will then
send back the full state including feedings and logged in
status.

This greatly improves the initial starting up experience
of the watch app! Also, this sets the stage for the watch to
have a simple UI mechanism to refresh the full state from the
main app!!