### PR TITLE
Surface watch <> phone communication error

### DIFF
--- a/BabyPatterns.xcodeproj/project.pbxproj
+++ b/BabyPatterns.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		1233CA222369F62D009BAF8E /* ContextReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1233CA212369F62D009BAF8E /* ContextReducer.swift */; };
 		123616AE20C5F43500185A27 /* TurnOffAdsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123616AC20C5F43500185A27 /* TurnOffAdsVC.swift */; };
 		123616AF20C5F43500185A27 /* TurnOffAdsVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 123616AD20C5F43500185A27 /* TurnOffAdsVC.xib */; };
+		123C1C1D236A849300AE084E /* FyiDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123C1C1C236A849300AE084E /* FyiDialog.swift */; };
 		123D4F93233691EB00F164E5 /* Library.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 120F80211FBF0E9500D04E45 /* Library.framework */; };
 		1243E4821FD6D9D000D727F1 /* FeedingStopwatchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1243E4811FD6D9D000D727F1 /* FeedingStopwatchView.swift */; };
 		1243E4841FD6DA4900D727F1 /* FeedingStopwatchView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1243E4831FD6DA4900D727F1 /* FeedingStopwatchView.xib */; };
@@ -57,7 +58,6 @@
 		1263ADFA23393A9400142056 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1263ADF923393A9400142056 /* Assets.xcassets */; };
 		1263ADFD23393A9400142056 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1263ADFC23393A9400142056 /* Preview Assets.xcassets */; };
 		1263AE0123393A9400142056 /* Baby Patterns.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 1263ADE223393A9200142056 /* Baby Patterns.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		126C44DD2358929A00C211A1 /* FyiDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 126C44DC2358929A00C211A1 /* FyiDialog.swift */; };
 		1289D18D20C167A800E73DA0 /* StopButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1289D18C20C167A800E73DA0 /* StopButton.swift */; };
 		128A56F720F56E2E00A4DC8E /* ProfileImageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 128A56F620F56E2E00A4DC8E /* ProfileImageCoordinator.swift */; };
 		128A56F820F56EB200A4DC8E /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43932C431E034E6400056F83 /* ProfileView.swift */; };
@@ -233,6 +233,7 @@
 		1233CA212369F62D009BAF8E /* ContextReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextReducer.swift; sourceTree = "<group>"; };
 		123616AC20C5F43500185A27 /* TurnOffAdsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnOffAdsVC.swift; sourceTree = "<group>"; };
 		123616AD20C5F43500185A27 /* TurnOffAdsVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TurnOffAdsVC.xib; sourceTree = "<group>"; };
+		123C1C1C236A849300AE084E /* FyiDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FyiDialog.swift; sourceTree = "<group>"; };
 		123D4F8E233691EB00F164E5 /* LibraryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LibraryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		123D4F90233691EB00F164E5 /* TimerLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerLabelTests.swift; sourceTree = "<group>"; };
 		1243E4811FD6D9D000D727F1 /* FeedingStopwatchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedingStopwatchView.swift; sourceTree = "<group>"; };
@@ -252,7 +253,6 @@
 		1263ADF923393A9400142056 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1263ADFC23393A9400142056 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		1263ADFE23393A9400142056 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		126C44DC2358929A00C211A1 /* FyiDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FyiDialog.swift; sourceTree = "<group>"; };
 		1289D18C20C167A800E73DA0 /* StopButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopButton.swift; sourceTree = "<group>"; };
 		128A56F620F56E2E00A4DC8E /* ProfileImageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageCoordinator.swift; sourceTree = "<group>"; };
 		128A56FB20F56F9200A4DC8E /* EditProfileImageVc.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditProfileImageVc.xib; sourceTree = "<group>"; };
@@ -456,7 +456,7 @@
 				12D0AF4A2347670A00725A56 /* TimerPulse.swift */,
 				120478EC234BE53800302AFD /* SessionCoordinator.swift */,
 				1263ADF523393A9300142056 /* HostingController.swift */,
-				126C44DC2358929A00C211A1 /* FyiDialog.swift */,
+				123C1C1C236A849300AE084E /* FyiDialog.swift */,
 				12F3EC28233D6BFB0051D52B /* HomeView.swift */,
 				120478EE234BEBB600302AFD /* LoggedOutView.swift */,
 				120478F0234BEC3400302AFD /* LoggedInHomeView.swift */,
@@ -1232,7 +1232,7 @@
 				12227F18235F232A004049DB /* PulseReducer.swift in Sources */,
 				12227F1A235F23AE004049DB /* SavedFyiDialogReducer.swift in Sources */,
 				1263ADF623393A9300142056 /* HostingController.swift in Sources */,
-				126C44DD2358929A00C211A1 /* FyiDialog.swift in Sources */,
+				123C1C1D236A849300AE084E /* FyiDialog.swift in Sources */,
 				120478ED234BE53800302AFD /* SessionCoordinator.swift in Sources */,
 				12E38A402343CEB500940F07 /* AppState.swift in Sources */,
 				1221F04E2344C9CC00E516D5 /* FeedingView.swift in Sources */,

--- a/BabyPatterns.xcodeproj/project.pbxproj
+++ b/BabyPatterns.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		123616AE20C5F43500185A27 /* TurnOffAdsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123616AC20C5F43500185A27 /* TurnOffAdsVC.swift */; };
 		123616AF20C5F43500185A27 /* TurnOffAdsVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 123616AD20C5F43500185A27 /* TurnOffAdsVC.xib */; };
 		123C1C1D236A849300AE084E /* FyiDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123C1C1C236A849300AE084E /* FyiDialog.swift */; };
+		123C1C1F236A898700AE084E /* CommunicationErrorReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123C1C1E236A898700AE084E /* CommunicationErrorReducer.swift */; };
 		123D4F93233691EB00F164E5 /* Library.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 120F80211FBF0E9500D04E45 /* Library.framework */; };
 		1243E4821FD6D9D000D727F1 /* FeedingStopwatchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1243E4811FD6D9D000D727F1 /* FeedingStopwatchView.swift */; };
 		1243E4841FD6DA4900D727F1 /* FeedingStopwatchView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1243E4831FD6DA4900D727F1 /* FeedingStopwatchView.xib */; };
@@ -234,6 +235,7 @@
 		123616AC20C5F43500185A27 /* TurnOffAdsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnOffAdsVC.swift; sourceTree = "<group>"; };
 		123616AD20C5F43500185A27 /* TurnOffAdsVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TurnOffAdsVC.xib; sourceTree = "<group>"; };
 		123C1C1C236A849300AE084E /* FyiDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FyiDialog.swift; sourceTree = "<group>"; };
+		123C1C1E236A898700AE084E /* CommunicationErrorReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicationErrorReducer.swift; sourceTree = "<group>"; };
 		123D4F8E233691EB00F164E5 /* LibraryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LibraryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		123D4F90233691EB00F164E5 /* TimerLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerLabelTests.swift; sourceTree = "<group>"; };
 		1243E4811FD6D9D000D727F1 /* FeedingStopwatchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedingStopwatchView.swift; sourceTree = "<group>"; };
@@ -413,6 +415,7 @@
 				12227F15235F2223004049DB /* AccountReducer.swift */,
 				12227F17235F232A004049DB /* PulseReducer.swift */,
 				12227F19235F23AE004049DB /* SavedFyiDialogReducer.swift */,
+				123C1C1E236A898700AE084E /* CommunicationErrorReducer.swift */,
 			);
 			path = "State Management";
 			sourceTree = "<group>";
@@ -1239,6 +1242,7 @@
 				12F3EC29233D6BFB0051D52B /* HomeView.swift in Sources */,
 				12E38A412343CEB500940F07 /* UnidirectionalFlow.swift in Sources */,
 				12D0AF4B2347670A00725A56 /* TimerPulse.swift in Sources */,
+				123C1C1F236A898700AE084E /* CommunicationErrorReducer.swift in Sources */,
 				1233CA222369F62D009BAF8E /* ContextReducer.swift in Sources */,
 				125BBC602367E37400CF3C70 /* FeedingReducer.swift in Sources */,
 				120478EF234BEBB600302AFD /* LoggedOutView.swift in Sources */,

--- a/Watch Extension/AddFeedingView.swift
+++ b/Watch Extension/AddFeedingView.swift
@@ -111,9 +111,9 @@ struct AddFeedingView: View {
                 self.isShowingSheet = false
             },
             errorHandler: { error in
-                // TODO: show communication error
                 print("Error sending the message: \(error.localizedDescription)")
-                assertionFailure()
+                self.isShowingSheet = false
+                self.store.send(.communicationErrorFyiDialog(.show))
             }
         )
     }

--- a/Watch Extension/FeedingView.swift
+++ b/Watch Extension/FeedingView.swift
@@ -41,19 +41,16 @@ struct FeedingView: View {
         WCSession.default.sendMessageData(
             d,
             replyHandler: { _ in
-                // TODO: add UI elements like the saved dialog here
                 switch action {
                 case .start: break
-                case .stop:
-                    self.store.send(.fyiDialog(.show))
+                case .stop: self.store.send(.fyiDialog(.show))
                 case .pause: break
                 case .resume: break
                 }
             },
             errorHandler: { error in
-                // TODO: show communication error
                 print("Error sending the message: \(error.localizedDescription)")
-                assertionFailure()
+                self.store.send(.communicationErrorFyiDialog(.show))
             }
         )
     }

--- a/Watch Extension/FyiDialog.swift
+++ b/Watch Extension/FyiDialog.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 
 struct FyiDialog: View {
-    // TODO: remove the requirement to have the full store
-    @ObservedObject var store: Store<AppState, AppAction>
-    @State private var isShowing = false
+    let text: Text
     let screenWidthPercent: CGFloat
-    private let disappearDuration: TimeInterval = 0.45
+    let backgroundColor: Color
+    let displayDuration: TimeInterval
+    let endAction: () -> Void
+
+    @State private var isShowing = false
 
     private func sideDimention(for metrics: GeometryProxy) -> CGFloat {
         isShowing ? metrics.size.width * screenWidthPercent : 10
@@ -16,11 +18,11 @@ struct FyiDialog: View {
             ZStack {
                 Rectangle()
                     .cornerRadius(12)
-                    .foregroundColor(Color.gray)
-                    .opacity(0.96)
+                    .foregroundColor(self.backgroundColor)
+                    .opacity(0.98)
 
-                Text("Saved!")
-                    .scaledFont(.notoSansBold, size: 16)
+                self.text
+                    .scaledFont(.notoSansSemiBold, size: 18)
                     .multilineTextAlignment(.center)
                     .foregroundColor(Color.white)
                     .opacity(self.isShowing ? 1.0 : 0.0)
@@ -34,11 +36,11 @@ struct FyiDialog: View {
             withAnimation(.spring()) {
                 self.isShowing = true
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                withAnimation(.easeIn(duration: self.disappearDuration)) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + self.displayDuration) {
+                withAnimation(.easeIn(duration: 0.45)) {
                     self.isShowing = false
-                    DispatchQueue.main.asyncAfter(deadline: .now() + self.disappearDuration) {
-                        self.store.send(.fyiDialog(.hide))
+                    DispatchQueue.main.asyncAfter(deadline: .now() + self.displayDuration) {
+                        self.endAction()
                     }
                 }
             }
@@ -50,7 +52,22 @@ struct FyiDialog: View {
 struct FyiDialog_Previews: PreviewProvider {
 // swiftlint:enable type_name
     static var previews: some View {
-        FyiDialog(store: Store(initialValue: AppState(), reducer: appReducer),
-                  screenWidthPercent: 0.5)
+        Group {
+            FyiDialog(text: Text("Saved!"),
+                      screenWidthPercent: 0.5,
+                      backgroundColor: Color.gray,
+                      displayDuration: 0.45,
+                      endAction: {})
+            FyiDialog(text: Text("Oh no!\nPlease try again."),
+                      screenWidthPercent: 0.75,
+                      backgroundColor: Color.red,
+                      displayDuration: 0.7,
+                      endAction: {})
+            FyiDialog(text: Text("Hello World!"),
+                      screenWidthPercent: 0.7,
+                      backgroundColor: Color.blue,
+                      displayDuration: 0.45,
+                      endAction: {})
+        }
     }
 }

--- a/Watch Extension/HomeView.swift
+++ b/Watch Extension/HomeView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /*
  TODO: - V1 Watch
  - Polish UI
- - clean up / fix popups
+ - Show spinner when sending message to phone
  */
 
 struct HomeView: View {

--- a/Watch Extension/LoggedInHomeView.swift
+++ b/Watch Extension/LoggedInHomeView.swift
@@ -75,7 +75,11 @@ struct LoggedInHomeView: View {
             })
 
             if store.value.showSavedFyiDialog {
-                FyiDialog(store: store, screenWidthPercent: 0.5)
+                FyiDialog(text: Text("Saved!"),
+                           screenWidthPercent: 0.5,
+                           backgroundColor: Color.gray,
+                           displayDuration: 1,
+                           endAction: { self.store.send(.communicationErrorFyiDialog(.hide)) })
             }
         }
     }

--- a/Watch Extension/LoggedInHomeView.swift
+++ b/Watch Extension/LoggedInHomeView.swift
@@ -48,33 +48,13 @@ struct LoggedInHomeView: View {
             }
             .edgesIgnoringSafeArea(.bottom)
 
-            // TODO: this needs UI work / to be abstracted?
-            GeometryReader { metrics in
-                ZStack {
-                    Rectangle()
-                        .cornerRadius(12)
-                        .foregroundColor(Color.blue)
-                        .opacity(0.96)
-
-                    VStack {
-                        Text("Connection Issue")
-                            .bold()
-                        Text("\nTry again or open main app.")
-                            .layoutPriority(1.0)
-                    }
-                    .multilineTextAlignment(.center)
-                    .foregroundColor(Color.white)
-                    .animation(.none)
-                }
-                .frame(width: self.alertDimension(for: metrics), height: self.alertDimension(for: metrics))
-            }
-            .opacity(false ? 1.0 : 0.0)
-            .animation(.spring(response: 0.45, dampingFraction: 0.7))
-            .gesture(TapGesture().onEnded {
-//                self.store.send(.communication(.clearFailedCommunication))
-            })
-
-            if store.value.showSavedFyiDialog {
+            if store.value.showCommunicationErrorFyiDialog {
+                FyiDialog(text: Text("Oh no!\nPlease try again."),
+                           screenWidthPercent: 0.75,
+                           backgroundColor: Color.red,
+                           displayDuration: 1.5,
+                           endAction: { self.store.send(.fyiDialog(.hide)) })
+            } else if store.value.showSavedFyiDialog {
                 FyiDialog(text: Text("Saved!"),
                            screenWidthPercent: 0.5,
                            backgroundColor: Color.gray,

--- a/Watch Extension/State Management/AppAction.swift
+++ b/Watch Extension/State Management/AppAction.swift
@@ -4,6 +4,7 @@ enum AppAction {
     case session(SessionAction)
     case pulse(PulseAction)
     case fyiDialog(SavedFyiDialogAction)
+    case communicationErrorFyiDialog(CommunicationErrorFyiDialogAction)
     case feeding(FeedingAction)
     case context(ContextAction)
 
@@ -39,6 +40,17 @@ enum AppAction {
         set {
             guard case .fyiDialog = self, let newValue = newValue else { return }
             self = .fyiDialog(newValue)
+        }
+    }
+
+    var communicationErrorFyiDialog: CommunicationErrorFyiDialogAction? {
+        get {
+            guard case let .communicationErrorFyiDialog(value) = self else { return nil }
+            return value
+        }
+        set {
+            guard case .communicationErrorFyiDialog = self, let newValue = newValue else { return }
+            self = .communicationErrorFyiDialog(newValue)
         }
     }
 

--- a/Watch Extension/State Management/AppReducer.swift
+++ b/Watch Extension/State Management/AppReducer.swift
@@ -4,6 +4,9 @@ let appReducer: (inout AppState, AppAction) -> Void = combine(
     pullback(accountStatusReducer, value: \.sessionState, action: \.session),
     pullback(pulseReducer, value: \.timerPulseCount, action: \.pulse),
     pullback(savedFyiDialogReducer, value: \.showSavedFyiDialog, action: \.savedFyiDialog),
+    pullback(communicationErrorFyiDialogReducer,
+             value: \.showCommunicationErrorFyiDialog,
+             action: \.communicationErrorFyiDialog),
     pullback(feedingReducer, value: \.activeFeedings, action: \.feeding),
     pullback(contextReducer, value: \.self, action: \.context)
 )

--- a/Watch Extension/State Management/AppState.swift
+++ b/Watch Extension/State Management/AppState.swift
@@ -5,6 +5,7 @@ struct AppState {
     var activeFeedings: [Feeding] = []
     var timerPulseCount: Int = 0
     var sessionState: SessionState = .loggedOut
+    var showCommunicationErrorFyiDialog = false
     /*
      TODO: think about this some more.
      I am not too sure how much I like this.

--- a/Watch Extension/State Management/CommunicationErrorReducer.swift
+++ b/Watch Extension/State Management/CommunicationErrorReducer.swift
@@ -1,0 +1,16 @@
+import Swift
+
+enum CommunicationErrorFyiDialogAction {
+    case show
+    case hide
+}
+
+func communicationErrorFyiDialogReducer(showCommunicationFyiDialog: inout Bool,
+                                        action: CommunicationErrorFyiDialogAction) {
+    switch action {
+    case .show:
+        showCommunicationFyiDialog = true
+    case .hide:
+        showCommunicationFyiDialog = false
+    }
+}


### PR DESCRIPTION
Leverages the now generic _FyiDialog_ popup to surface a watch <> phone communication error (e.g., stop, pause, etc.).

See individual commit messages for further details.