### PR TITLE
Improve watch logged in state

### DIFF
--- a/Watch Extension/HomeView.swift
+++ b/Watch Extension/HomeView.swift
@@ -25,6 +25,9 @@ struct HomeView: View {
                 LoggedOutHomeView()
             }
         }
+        .onAppear {
+            self.store.send(.context(.requestFullContext))
+        }
     }
 }
 


### PR DESCRIPTION
Sometimes the Watch will say logged out
when there is an account on the main app.

So, this will request the full context for the app
on watch app start up.

Attempt at resolving: https://github.com/jasonzurita/BabyPatterns/issues/35