### PR TITLE
Implement local stores

### DIFF
--- a/Watch Extension/AddFeedingView.swift
+++ b/Watch Extension/AddFeedingView.swift
@@ -50,8 +50,13 @@ struct FeedingOptionsView: View {
     }
 }
 
+enum AddFeedingViewAction {
+    case communicationErrorFyiDialog(CommunicationErrorFyiDialogAction)
+    case loading(LoadingAction)
+}
+
 struct AddFeedingView: View {
-    @ObservedObject var store: Store<AppState, AppAction>
+    @ObservedObject var store: Store<[Feeding], AddFeedingViewAction>
     @Binding var isShowingSheet: Bool
     @State private var feedingIntent: FeedingType = .none
 
@@ -61,7 +66,7 @@ struct AddFeedingView: View {
             // store will reflect in the below view since we are just passing an array in and
             // not some kind of binding
             FeedingOptionsView(feedingIntent: $feedingIntent,
-                               activeFeedingTypes: store.value.activeFeedings.map { $0.type })
+                               activeFeedingTypes: store.value.map { $0.type })
             GeometryReader { metrics in
                 ZStack {
                     Rectangle()
@@ -123,8 +128,20 @@ struct AddFeedingView: View {
 // swiftlint:disable type_name
 struct AddFeedingView_Previews: PreviewProvider {
 // swiftlint:enable type_name
+    static let store = Store(initialValue: AppState(), reducer: appReducer)
     static var previews: some View {
-        AddFeedingView(store: Store(initialValue: AppState(), reducer: appReducer),
-                       isShowingSheet: .constant(true))
+        AddFeedingView(store:
+            store.view(
+                value: { $0.activeFeedings },
+                action: {
+                    switch $0 {
+                    case let .communicationErrorFyiDialog(action):
+                        return .communicationErrorFyiDialog(action)
+                    case let .loading(action):
+                        return .loading(action)
+                    }
+                }
+            ), isShowingSheet: .constant(true)
+        )
     }
 }

--- a/Watch Extension/FeedingView.swift
+++ b/Watch Extension/FeedingView.swift
@@ -2,8 +2,14 @@ import Common
 import SwiftUI
 import WatchConnectivity
 
+enum FeedingViewAction {
+    case communicationErrorFyiDialog(CommunicationErrorFyiDialogAction)
+    case fyiDialog(SavedFyiDialogAction)
+    case loading(LoadingAction)
+}
+
 struct FeedingView: View {
-    @ObservedObject var store: Store<AppState, AppAction>
+    @ObservedObject var store: Store<[Feeding], FeedingViewAction>
     let feeding: Feeding
     @State private var isShowingActionSheet = false
 
@@ -100,6 +106,9 @@ struct FeedingView: View {
 // swiftlint:disable type_name
 struct FeedingView_Previews: PreviewProvider {
 // swiftlint:enable type_name
+
+    static let store = Store(initialValue: AppState(), reducer: appReducer)
+
     static let feeding = Feeding(type: .nursing,
                                  side: .left,
                                  startDate: Date() - 3355,
@@ -115,10 +124,36 @@ struct FeedingView_Previews: PreviewProvider {
 
     static var previews: some View {
         Group {
-            FeedingView(store: Store(initialValue: AppState(), reducer: appReducer),
-                        feeding: FeedingView_Previews.feeding)
-            FeedingView(store: Store(initialValue: AppState(), reducer: appReducer),
-                        feeding: FeedingView_Previews.feedingPaused)
+            FeedingView(store:
+                store.view(
+                    value: { $0.activeFeedings },
+                    action: {
+                        switch $0 {
+                        case let .communicationErrorFyiDialog(action):
+                            return .communicationErrorFyiDialog(action)
+                        case let .fyiDialog(action):
+                            return .fyiDialog(action)
+                        case let .loading(action):
+                            return .loading(action)
+                        }
+                    }
+                ), feeding: feeding
+            )
+            FeedingView(store:
+                store.view(
+                    value: { $0.activeFeedings },
+                    action: {
+                        switch $0 {
+                        case let .communicationErrorFyiDialog(action):
+                            return .communicationErrorFyiDialog(action)
+                        case let .fyiDialog(action):
+                            return .fyiDialog(action)
+                        case let .loading(action):
+                            return .loading(action)
+                        }
+                    }
+                ), feeding: feedingPaused
+            )
         }
     }
 }

--- a/Watch Extension/SessionCoordinator.swift
+++ b/Watch Extension/SessionCoordinator.swift
@@ -2,9 +2,15 @@ import Common
 import Foundation
 import WatchConnectivity
 
+enum SessionCoordinatorAction {
+    case session(SessionAction)
+    case context(ContextAction)
+    case feeding(FeedingAction)
+}
+
 final class SessionCoordinator: NSObject {
     static let shared = SessionCoordinator()
-    weak var store: Store<AppState, AppAction>? {
+    var store: Store<Void, SessionCoordinatorAction>? {
         didSet {
             store?.send(.context(.requestFullContext))
         }

--- a/Watch Extension/TimerPulse.swift
+++ b/Watch Extension/TimerPulse.swift
@@ -5,7 +5,7 @@ final class TimerPulse {
     // TODO: need to manage the timer by hooking into the app's lifecycle
     static let shared = TimerPulse()
 
-    weak var store: Store<AppState, AppAction>?
+    var store: Store<Void, PulseAction>?
     private var timer: Timer?
 
     func start() {
@@ -14,7 +14,7 @@ final class TimerPulse {
         // a new timer is added to the main runloop (aka the main thread)
         timer = Current.scheduledTimer(1, true) { [weak self] _ in
             guard let self = self else { return }
-            self.store?.send(.pulse(.timerPulse))
+            self.store?.send(.timerPulse)
         }
     }
 

--- a/Watch Extension/UnidirectionalFlow.swift
+++ b/Watch Extension/UnidirectionalFlow.swift
@@ -1,8 +1,10 @@
 import Foundation
+import Combine
 
 final class Store<Value, Action>: ObservableObject {
     private let reducer: (inout Value, Action) -> Void
     @Published private(set) var value: Value
+    private var cancellable: Cancellable?
 
     init(initialValue: Value, reducer: @escaping (inout Value, Action) -> Void) {
         self.reducer = reducer
@@ -13,6 +15,23 @@ final class Store<Value, Action>: ObservableObject {
         DispatchQueue.main.async {
             self.reducer(&self.value, action)
         }
+    }
+
+    func view<LocalValue, LocalAction>(
+        value toLocalValue: @escaping (Value) -> LocalValue,
+        action toGlobalAction: @escaping (LocalAction) -> Action
+    ) -> Store<LocalValue, LocalAction> {
+        let localStore = Store<LocalValue, LocalAction>(
+            initialValue: toLocalValue(value),
+            reducer: { localValue, localAction in
+                self.send(toGlobalAction(localAction))
+                localValue = toLocalValue(self.value)
+            }
+        )
+        localStore.cancellable = self.$value.sink { [weak localStore] newValue in
+            localStore?.value = toLocalValue(newValue)
+        }
+        return localStore
     }
 }
 


### PR DESCRIPTION
Each object that needs a store may now
use a store that is focused in on what that object
actually _needs_ rather than the whole AppState and
AppAction.

This:
- improves clarity
- reduces potential for future bugs
- supports future modularization & testing