### PR TITLE
Add ability to re-sync logged in state

### DIFF
--- a/Watch Extension/HomeView.swift
+++ b/Watch Extension/HomeView.swift
@@ -50,7 +50,12 @@ struct HomeView: View {
                     )
                 )
             } else {
-                LoggedOutHomeView()
+                LoggedOutHomeView(store:
+                    store.view(
+                        value: { _ in },
+                        action: { .context($0) }
+                    )
+                )
             }
         }
         .onAppear {

--- a/Watch Extension/LoggedOutView.swift
+++ b/Watch Extension/LoggedOutView.swift
@@ -1,26 +1,42 @@
 import SwiftUI
 
 struct LoggedOutHomeView: View {
+    @ObservedObject var store: Store<Void, ContextAction>
+
     var body: some View {
         VStack {
             Spacer()
             Text("Welcome!")
                 .scaledFont(.notoSansBold, size: 30)
-            Spacer()
-            Text("Create an account using the main app to get started!")
-                .scaledFont(.notoSansRegular, size: 18)
+            Text("No account found.\nRetry?")
+                .scaledFont(.notoSansRegular, size: 16)
                 .foregroundColor(.bpMediumGray)
                 .layoutPriority(1.0)
+            Button(action: {
+                self.store.send(.requestFullContext)
+            }, label: {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 36))
+                    .foregroundColor(.bpMediumBlue)
+            })
+            .buttonStyle(PlainButtonStyle())
             Spacer()
         }
         .multilineTextAlignment(.center)
+        .edgesIgnoringSafeArea(.bottom)
     }
 }
 
 // swiftlint:disable type_name
 struct LoggedOutHomeView_Previews: PreviewProvider {
 // swiftlint:enable type_name
+    static let store = Store(initialValue: AppState(), reducer: appReducer)
     static var previews: some View {
-        LoggedOutHomeView()
+        LoggedOutHomeView(store:
+            store.view(
+                value: { _ in },
+                action: { .context($0) }
+            )
+        )
     }
 }


### PR DESCRIPTION
This adds a _request current context_ button to the logged out
screen.

In the case where the Watch app needs a little
extra help syncing the current logged in state from the
main app. This _out of sync_ situation seems to sometimes
happen...

Attempt at resolving: https://github.com/jasonzurita/BabyPatterns/issues/35