### PR TITLE
Implement async side effects

### DIFF
--- a/Watch Extension/State Management/AccountReducer.swift
+++ b/Watch Extension/State Management/AccountReducer.swift
@@ -10,12 +10,14 @@ enum SessionAction {
     case loggedOut
 }
 
-func accountStatusReducer(sessionState: inout SessionState, action: SessionAction) {
+func accountStatusReducer(sessionState: inout SessionState, action: SessionAction) -> [Effect<SessionAction>] {
     switch action {
     // TODO: can logged out and logged in be combined?
     case .loggedIn:
         sessionState = .loggedIn
+        return []
     case .loggedOut:
         sessionState = .loggedOut
+        return []
     }
 }

--- a/Watch Extension/State Management/AppReducer.swift
+++ b/Watch Extension/State Management/AppReducer.swift
@@ -1,6 +1,6 @@
 import Swift
 
-let appReducer: (inout AppState, AppAction) -> Void = combine(
+let appReducer: Reducer<AppState, AppAction> = combine(
     pullback(accountStatusReducer, value: \.sessionState, action: \.session),
     pullback(pulseReducer, value: \.timerPulseCount, action: \.pulse),
     pullback(savedFyiDialogReducer, value: \.showSavedFyiDialog, action: \.savedFyiDialog),

--- a/Watch Extension/State Management/CommunicationErrorReducer.swift
+++ b/Watch Extension/State Management/CommunicationErrorReducer.swift
@@ -5,12 +5,16 @@ enum CommunicationErrorFyiDialogAction {
     case hide
 }
 
-func communicationErrorFyiDialogReducer(showCommunicationFyiDialog: inout Bool,
-                                        action: CommunicationErrorFyiDialogAction) {
+func communicationErrorFyiDialogReducer(
+    showCommunicationFyiDialog: inout Bool,
+    action: CommunicationErrorFyiDialogAction
+) -> [Effect<CommunicationErrorFyiDialogAction>] {
     switch action {
     case .show:
         showCommunicationFyiDialog = true
+        return []
     case .hide:
         showCommunicationFyiDialog = false
+        return []
     }
 }

--- a/Watch Extension/State Management/ContextReducer.swift
+++ b/Watch Extension/State Management/ContextReducer.swift
@@ -9,12 +9,13 @@ enum ContextAction {
 // TODO: need to figure out how to remove the state from here since
 // there is no need to have it at all. This reducer is to just formalize
 // an action
-func contextReducer(state _: inout AppState, action: ContextAction) {
+func contextReducer(state _: inout AppState, action: ContextAction) -> [Effect<ContextAction>] {
     switch action {
     case .requestFullContext:
         let communication = WatchContextCommunication()
         let encoder = JSONEncoder()
-        guard let data = try? encoder.encode(communication) else { return }
+        guard let data = try? encoder.encode(communication) else { return [] }
         WCSession.default.sendMessageData(data, replyHandler: nil, errorHandler: nil)
+        return []
     }
 }

--- a/Watch Extension/State Management/FeedingReducer.swift
+++ b/Watch Extension/State Management/FeedingReducer.swift
@@ -5,11 +5,12 @@ enum FeedingAction {
     case update(feedings: [Feeding])
 }
 
-func feedingReducer(value: inout [Feeding], action: FeedingAction) {
+func feedingReducer(value: inout [Feeding], action: FeedingAction) -> [Effect<FeedingAction>] {
     switch action {
     case let .update(feedings):
         // TODO: show all after formatting the list view UI better
         // This will also reqire better handleing pause/resume/stop reducer actions
         value = feedings.filter { !$0.isFinished }
+        return []
     }
 }

--- a/Watch Extension/State Management/LoadingReducer.swift
+++ b/Watch Extension/State Management/LoadingReducer.swift
@@ -6,11 +6,13 @@ enum LoadingAction {
 }
 
 func loadingReducer(isLoading: inout Bool,
-                    action: LoadingAction) {
+                    action: LoadingAction) -> [Effect<LoadingAction>] {
     switch action {
     case .loading:
         isLoading = true
+        return []
     case .notLoading:
         isLoading = false
+        return []
     }
 }

--- a/Watch Extension/State Management/PulseReducer.swift
+++ b/Watch Extension/State Management/PulseReducer.swift
@@ -4,9 +4,10 @@ enum PulseAction {
     case timerPulse
 }
 
-func pulseReducer(timerPulseCount: inout Int, action: PulseAction) {
+func pulseReducer(timerPulseCount: inout Int, action: PulseAction) -> [Effect<PulseAction>] {
     switch action {
     case .timerPulse:
         timerPulseCount += 1
+        return []
     }
 }

--- a/Watch Extension/State Management/SavedFyiDialogReducer.swift
+++ b/Watch Extension/State Management/SavedFyiDialogReducer.swift
@@ -5,11 +5,14 @@ enum SavedFyiDialogAction {
     case hide
 }
 
-func savedFyiDialogReducer(showSavedFyiDialog: inout Bool, action: SavedFyiDialogAction) {
+func savedFyiDialogReducer(showSavedFyiDialog: inout Bool,
+                           action: SavedFyiDialogAction) -> [Effect<SavedFyiDialogAction>] {
     switch action {
     case .show:
         showSavedFyiDialog = true
+        return []
     case .hide:
         showSavedFyiDialog = false
+        return []
     }
 }


### PR DESCRIPTION
to allow the reducers to produce side effects:
- they can be async like network calls
- they can feed back into the store, thus preserving
the unidirectional flow architecture

This will help keep the reducers "pure" and make
side effects formal.

Upcoming work includes better watchkit communication!