### PR TITLE
Show error popup if we can't get context!

### DIFF
--- a/Watch Extension/State Management/AppReducer.swift
+++ b/Watch Extension/State Management/AppReducer.swift
@@ -9,5 +9,5 @@ let appReducer: Reducer<AppState, AppAction> = combine(
              action: \.communicationErrorFyiDialog),
     pullback(loadingReducer, value: \.isLoading, action: \.loading),
     pullback(feedingReducer, value: \.activeFeedings, action: \.feeding),
-    pullback(contextReducer, value: \.self, action: \.context)
+    pullback(contextReducer, value: \.showCommunicationErrorFyiDialog, action: \.context)
 )

--- a/Watch Extension/State Management/ContextReducer.swift
+++ b/Watch Extension/State Management/ContextReducer.swift
@@ -4,18 +4,28 @@ import WatchConnectivity
 
 enum ContextAction {
     case requestFullContext
+    case fullContextRequestFailed
 }
 
 // TODO: need to figure out how to remove the state from here since
 // there is no need to have it at all. This reducer is to just formalize
 // an action
-func contextReducer(state _: inout AppState, action: ContextAction) -> [Effect<ContextAction>] {
+func contextReducer(showCommunicationErrorFyiDialog: inout Bool, action: ContextAction) -> [Effect<ContextAction>] {
     switch action {
     case .requestFullContext:
-        let communication = WatchContextCommunication()
-        let encoder = JSONEncoder()
-        guard let data = try? encoder.encode(communication) else { return [] }
-        WCSession.default.sendMessageData(data, replyHandler: nil, errorHandler: nil)
+        return [ { callback in
+            let communication = WatchContextCommunication()
+            let encoder = JSONEncoder()
+            guard let data = try? encoder.encode(communication) else { return }
+            WCSession.default.sendMessageData(data, replyHandler: nil, errorHandler: { _ in
+                callback(.fullContextRequestFailed)
+            })
+        },
+        ]
+    case .fullContextRequestFailed:
+        showCommunicationErrorFyiDialog = true
+        // TODO: we can formalize the removal of the fyi dialog here with a
+        // side effect dispatch async and a new action!
         return []
     }
 }


### PR DESCRIPTION
use the [recently added side effects support](https://github.com/jasonzurita/BabyPatterns/pull/41) to
show a communication failure popup if getting the
context fails!