### PR TITLE
Prevent false comm error

### DIFF
--- a/Watch Extension/SessionCoordinator.swift
+++ b/Watch Extension/SessionCoordinator.swift
@@ -11,11 +11,7 @@ enum SessionCoordinatorAction {
 
 final class SessionCoordinator: NSObject {
     static let shared = SessionCoordinator()
-    var store: Store<Void, SessionCoordinatorAction>? {
-        didSet {
-            store?.send(.context(.requestFullContext))
-        }
-    }
+    var store: Store<Void, SessionCoordinatorAction>?
 
     override init() {
         super.init()


### PR DESCRIPTION
This happens because this call
to get the context was too early in the lifecycle
to make the context request, and would fail every time.

This was being hidden by implicit dispatch all to main
that was recently removed, so this bug popped up, which was
already there but hidden.