### PR TITLE
Make use of `receiveOn` over manual dispatch

### DIFF
--- a/Cycle/Sources/Cycle/Core.swift
+++ b/Cycle/Sources/Cycle/Core.swift
@@ -1,19 +1,6 @@
 import Foundation
 import Combine
 
-public struct Effect<A> {
-    public let run: (@escaping (A) -> Void) -> Void
-
-    public init(run: @escaping (@escaping (A) -> Void) -> Void) {
-        self.run = run
-    }
-
-    public func map<B>(_ f: @escaping (A) -> B) -> Effect<B> {
-        return Effect<B> { callback in self.run { a in callback(f(a)) }
-        }
-    }
-}
-
 public typealias Reducer<Value, Action> = (inout Value, Action) -> [Effect<Action>]
 
 public final class Store<Value, Action>: ObservableObject {

--- a/Cycle/Sources/Cycle/Effect.swift
+++ b/Cycle/Sources/Cycle/Effect.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public struct Effect<A> {
+    public let run: (@escaping (A) -> Void) -> Void
+
+    public init(run: @escaping (@escaping (A) -> Void) -> Void) {
+        self.run = run
+    }
+
+    public func map<B>(_ f: @escaping (A) -> B) -> Effect<B> {
+        return Effect<B> { callback in self.run { a in callback(f(a)) }
+        }
+    }
+}
+
+extension Effect {
+    public func receive(on queue: DispatchQueue) -> Effect {
+        return Effect { callback in
+            self.run { a in
+                queue.async {
+                    callback(a)
+                }
+            }
+        }
+    }
+}

--- a/Watch Extension/State Management/ContextReducer.swift
+++ b/Watch Extension/State Management/ContextReducer.swift
@@ -20,7 +20,8 @@ func contextReducer(showCommunicationErrorFyiDialog: inout Bool, action: Context
                 WCSession.default.sendMessageData(data, replyHandler: nil, errorHandler: { _ in
                     DispatchQueue.main.async { callback(.fullContextRequestFailed) }
                 })
-            },
+            }
+            .receive(on: .main),
         ]
     case .fullContextRequestFailed:
         showCommunicationErrorFyiDialog = true

--- a/Watch Extension/State Management/FeedingReducer.swift
+++ b/Watch Extension/State Management/FeedingReducer.swift
@@ -38,20 +38,21 @@ func feedingReducer(feedingState: inout FeedingState, action: FeedingAction) -> 
                 WCSession.default.sendMessageData(
                     d,
                     replyHandler: { _ in
-                        defer { DispatchQueue.main.async { callback(.loadingFinished) } }
+                        defer { callback(.loadingFinished) }
                         switch action {
                         case .start: break
                         case .stop:
-                            DispatchQueue.main.async { callback(.showFeedingStopped) }
+                            callback(.showFeedingStopped)
                         case .pause: break
                         case .resume: break
                         }
                 },
                     errorHandler: { error in
                         print("Error sending the message: \(error.localizedDescription)")
-                        DispatchQueue.main.async { callback(.communicationFailed) }
+                        callback(.communicationFailed)
                 })
-            },
+            }
+            .receive(on: .main),
         ]
     case .communicationFailed:
         feedingState.showCommunicationFyiDialog = true


### PR DESCRIPTION
This lets the Effect implementation take ownership
of the queue that an effect turns on over force dispatching.

Also, move Effect type out into separate file for better separation of
code.