### PR TITLE
Plot history graph bars using event start date

### DIFF
--- a/BabyPatterns/FeedingVC.swift
+++ b/BabyPatterns/FeedingVC.swift
@@ -3,21 +3,20 @@ import Framework_BabyPatterns
 import Library
 import UIKit
 
-struct EndFeedingEvent: Event {
-    let endDate: Date
+struct EndedFeedingEvent: Event {
+    let startDate: Date
     let type: FeedingType
     let side: FeedingSide
     let duration: TimeInterval
     let supplyAmount: SupplyAmount
 
-    init?(date: Date?,
+    init?(startDate: Date,
           type: FeedingType,
           side: FeedingSide,
           duration: TimeInterval,
           supplyAmount: SupplyAmount
     ) {
-        guard let d = date else { return nil }
-        endDate = d
+        self.startDate = startDate
         self.type = type
         self.side = side
         self.duration = duration
@@ -50,12 +49,12 @@ final class FeedingVC: UIViewController {
         guard let vm = feedingsVM else { return [] }
         return vm
             .feedings(withTypes: [.nursing, .bottle, .pumping], isFinished: true)
-            .compactMap { EndFeedingEvent(date: $0.endDate,
+            .compactMap { EndedFeedingEvent(startDate: $0.startDate,
                                           type: $0.type,
                                           side: $0.side,
                                           duration: $0.duration(),
                                           supplyAmount: $0.supplyAmount) }
-            .sorted { $0.endDate > $1.endDate }
+            .sorted { $0.startDate > $1.startDate }
     }
 
     @IBOutlet var showHistoryButton: UIButton! {

--- a/Framework-BabyPatterns/History/HistoryVc.swift
+++ b/Framework-BabyPatterns/History/HistoryVc.swift
@@ -3,7 +3,7 @@ import Library
 import UIKit
 
 public protocol Event {
-    var endDate: Date { get }
+    var startDate: Date { get }
     var type: FeedingType { get }
     var side: FeedingSide { get }
     var duration: TimeInterval { get }
@@ -247,7 +247,7 @@ extension HistoryVc {
         scrollContentView.subviews.forEach { $0.removeFromSuperview() }
         scrollContentView.layer.sublayers?.forEach { $0.removeFromSuperlayer() }
 
-        let graphWindow = DateInterval(start: lastEvent.endDate, end: Date())
+        let graphWindow = DateInterval(start: lastEvent.startDate, end: Date())
         layoutFeedings(events, inWindow: graphWindow)
 
         // TODO: see if we can move this before the event check
@@ -256,7 +256,7 @@ extension HistoryVc {
 
     private func layoutFeedings(_ events: [Event], inWindow window: DateInterval) {
         for event in events {
-            let x = xFeedingLocation(forDate: event.endDate, inWindow: window)
+            let x = xFeedingLocation(forDate: event.startDate, inWindow: window)
 
             let graphElement = TapableView()
             graphElement.onTap = { [unowned self] element in
@@ -300,7 +300,7 @@ extension HistoryVc {
         let sideString = event.side == .none ? "" : " (\(event.side.asText()))"
 
         let detailLabelTextOptions: [([FeedingType], String)] = [
-            ([.nursing, .pumping, .bottle], df.string(from: event.endDate)),
+            ([.nursing, .pumping, .bottle], df.string(from: event.startDate)),
             ([.nursing, .pumping], "\(hours.string)h \(minutes.string)m long\(sideString)"),
             ([.pumping, .bottle], "\(event.supplyAmount.displayText(for: .ounces))"),
         ]


### PR DESCRIPTION
After changing the summary to use the start
date, the graph needed to also be switched over too.
This corrects that.

This disconnect between the history stats and bar graph
is a source of weakness. As a result, this dependency could
use some tests or an effort to codify the dependency so this
doesn't happen again.